### PR TITLE
Fail if there are dead screens and try to prevent dead screens from happening

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,2 @@
+skip_list:
+ - '405' # adding retry until could be done later

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,6 +9,6 @@ galaxy_info:
   - name: EL
     versions:
     - 7
-  categories:
+  galaxy_tags:
   - system
   dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,7 +66,7 @@
   when: stress_procs.stdout < 1
 
 - name: Get dead screen count
-  shell: sceren -ls|grep -c Dead
+  shell: screen -ls|grep -c Dead
   register: reg_dead_screens
   changed_when: False
   check_mode: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -76,4 +76,4 @@
 - name: Fail if there are dead screens
   fail:
     msg: Found dead screens. stress-ng probably did not start. Run screen -wipe and try again.
-  when: reg_dead_screens.stdout > 0
+  when: reg_dead_screens.stdout|int > 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Fail if existing screen session
   fail:
     msg: A stress session is already running. It might be some pending writes to disk.
-  when: screen_files.matched != 0 and skip_screen_check == False
+  when: screen_files.matched != 0 and not skip_screen_check
 
 - name: install dependencies for building stress-ng
   yum: name=libattr-devel,keyutils-libs-devel,make,gcc,tar state=present
@@ -33,24 +33,24 @@
     creates: '/usr/bin/stress-ng'
 
 - name: create a temp dir for stress to use
-  file: path="{{stress_tmp_dir}}" state=directory
+  file: path="{{ stress_tmp_dir }}" state=directory
 
 - name: run stress-ng
   command: >
     screen -S stress -d -m
     stress-ng
-    --timeout {{test_duration}}
-    --hdd-bytes {{bytes_per_hdd_worker}}
-    --vm-bytes {{bytes_per_vm_worker}}
+    --timeout {{ test_duration }}
+    --hdd-bytes {{ bytes_per_hdd_worker }}
+    --vm-bytes {{ bytes_per_vm_worker }}
     --vm-method all
     --cpu-method all
-    --cpu {{cpu_workers}}
-    --vm {{vm_workers}}
-    --hdd {{hdd_workers}}
-    --log-file {{stress_tmp_dir}}/stress-ng-{{ ansible_date_time.iso8601_basic_short }}.log
+    --cpu {{ cpu_workers }}
+    --vm {{ vm_workers }}
+    --hdd {{ hdd_workers }}
+    --log-file {{ stress_tmp_dir }}/stress-ng-{{ ansible_date_time.iso8601_basic_short }}.log
     ; sleep 2
   args:
-    chdir: "{{stress_tmp_dir}}"
+    chdir: "{{ stress_tmp_dir }}"
   tags: skip_ansible_lint
 
 - name: Get stress-ng process count

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,6 +48,7 @@
     --vm {{vm_workers}}
     --hdd {{hdd_workers}}
     --log-file {{stress_tmp_dir}}/stress-ng-{{ ansible_date_time.iso8601_basic_short }}.log
+    && sleep 2
   args:
     chdir: "{{stress_tmp_dir}}"
   tags: skip_ansible_lint

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,7 +48,7 @@
     --vm {{vm_workers}}
     --hdd {{hdd_workers}}
     --log-file {{stress_tmp_dir}}/stress-ng-{{ ansible_date_time.iso8601_basic_short }}.log
-    && sleep 2
+    ; sleep 2
   args:
     chdir: "{{stress_tmp_dir}}"
   tags: skip_ansible_lint

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,6 +70,7 @@
   register: reg_dead_screens
   changed_when: False
   check_mode: False
+  failed_when: False
   tags: skip_ansible_lint
 
 - name: Fail if there are dead screens

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -63,3 +63,15 @@
   fail:
     msg: No stress-ng processes found!
   when: stress_procs.stdout < 1
+
+- name: Get dead screen count
+  shell: sceren -ls|grep -c Dead
+  register: reg_dead_screens
+  changed_when: False
+  check_mode: False
+  tags: skip_ansible_lint
+
+- name: Fail if there are dead screens
+  fail:
+    msg: Found dead screens. stress-ng probably did not start. Run screen -wipe and try again.
+  when: reg_dead_screens.stdout > 0

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -145,13 +145,13 @@ function main(){
 #    show_version
 #    tree_list
 #    test_install_requirements
-    test_ansible_lint
     test_ansible_setup
     test_playbook_syntax
     test_playbook
     test_playbook_check
 #    extra_tests
     test_verification
+    test_ansible_lint
 
 }
 


### PR DESCRIPTION
 - Fail on dead screens (done with a screen -ls and grep)
 - Try to prevent dead screens (done with a ; sleep 2 after the screen command)