### PR TITLE
Ensure that folder for FIO stress exists

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,11 @@
     path: "{{ stress_tmp_dir }}"
     state: directory
 
+- name: Create a dir for fio stress testing
+  file:
+    path: "{{ ssd_tests_folder }}"
+    state: directory
+
 - name: Run stress_tests
   command: >
     screen -S stress -d -m


### PR DESCRIPTION
The ansible role currently assumes that the folder used by FIO stress
testing exists. Nevertheless, this folder is not present in the system
by default, so launching the stress testing script fails because the
directory does not exist. This fix makes sure that the folder is present
before launching the stress testing script.