### PR TITLE
Ensure that folder for FIO stress exists

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,11 @@
     path: "{{ stress_tmp_dir }}"
     state: directory
 
+- name: Create a dir for fio stress testing
+  file:
+    path: "{{ ssd_tests_folder }}"
+    state: directory
+
 - name: Run stress_tests
   command: >
     screen -S stress -d -m

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -152,7 +152,6 @@ function main(){
     test_playbook
 # /media/stress_test should exists after running ansible
     test -d "/media/stress_test" || (echo "Failure: /media/stress_test does not exist after running ansible playbook" && exit 1)
-    test_fio_folder_presence
     test_playbook_check
 #    extra_tests
     test_verification

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -147,7 +147,12 @@ function main(){
 #    test_install_requirements
     test_ansible_setup
     test_playbook_syntax
+# /media/stress_test should not exists before running ansible
+    test ! -d "/media/stress_test"
     test_playbook
+# /media/stress_test should exists after running ansible
+    test -d "/media/stress_test"
+    test_fio_folder_presence
     test_playbook_check
 #    extra_tests
     test_verification

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -148,10 +148,10 @@ function main(){
     test_ansible_setup
     test_playbook_syntax
 # /media/stress_test should not exists before running ansible
-    test ! -d "/media/stress_test"
+    test ! -d "/media/stress_test" || (echo "Failure: /media/stress_test exists before running ansible playbook" && exit 1)
     test_playbook
 # /media/stress_test should exists after running ansible
-    test -d "/media/stress_test"
+    test -d "/media/stress_test" || (echo "Failure: /media/stress_test does not exist after running ansible playbook" && exit 1)
     test_fio_folder_presence
     test_playbook_check
 #    extra_tests


### PR DESCRIPTION
The ansible role currently assumes that the folder used by FIO stress
testing exists. Nevertheless, this folder is not present in the system
by default, so launching the stress testing script fails because the
directory does not exist. This fix makes sure that the folder is present
before launching the stress testing script.